### PR TITLE
Refresh UI: neon-synced accent, glass surfaces, real Skills page, con…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       }
     },
@@ -649,8 +650,8 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -662,8 +663,8 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1674,32 +1675,32 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "optional": true,
-      "peer": true
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -2894,8 +2895,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3164,11 +3165,11 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "optional": true,
-      "peer": true,
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4157,6 +4158,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -8166,8 +8181,8 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8210,8 +8225,8 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -8431,8 +8446,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -8811,8 +8826,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }

--- a/src/app/components/canvasBackground/canvasBackground.tsx
+++ b/src/app/components/canvasBackground/canvasBackground.tsx
@@ -127,10 +127,8 @@ export default function CanvasBackground() {
             }
         }
 
-        // Animation loop
-        function loop() {
-            window.requestAnimationFrame(loop);
-
+        // Draw a single frame of the animation
+        function frame() {
             ++tick;
 
             if (ctx !== null && canvas !== null) {
@@ -148,8 +146,21 @@ export default function CanvasBackground() {
             }
         }
 
-        // Start the animation loop
-        loop();
+        // Animation loop
+        function loop() {
+            window.requestAnimationFrame(loop);
+            frame();
+        }
+
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            // Render a static composition instead of animating
+            for (let i = 0; i < 500; i++) {
+                frame();
+            }
+        } else {
+            // Start the animation loop
+            loop();
+        }
 
         // Handle window resize
         const handleResize = () => {

--- a/src/app/components/navbar/navbar.tsx
+++ b/src/app/components/navbar/navbar.tsx
@@ -5,10 +5,10 @@ import { Disclosure } from '@headlessui/react'
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
 
 const navigation = [
-    { name: 'About Me', href: '/', current: true },
-    { name: 'Experience', href: '/experience', current: false },
-    { name: 'Skills', href: '#', current: false },
-    { name: 'Contact', href: '/contact', current: false },
+    { name: 'About Me', href: '/' },
+    { name: 'Experience', href: '/experience' },
+    { name: 'Skills', href: '/skills' },
+    { name: 'Contact', href: '/contact' },
 ]
 
 function classNames(...classes: string[]) {
@@ -17,11 +17,9 @@ function classNames(...classes: string[]) {
 
 export default function Navbar() {
     const pathUrl = usePathname();
-    navigation.forEach(item => {
-        item.current = item.href === pathUrl;
-    });
+    const isCurrent = (href: string) => href === pathUrl;
     return (
-        <Disclosure as="nav" id='navbar' className="bg-gray-800">
+        <Disclosure as="nav" id='navbar' className="glass sticky top-0 z-10 border-x-0 border-t-0">
             {({ open }) => (
                 <>
                     <div id="navbar-desktop" className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">
@@ -39,8 +37,9 @@ export default function Navbar() {
                                 </Disclosure.Button>
                             </div>
                             <div className="flex flex-1 items-center justify-center sm:items-stretch sm:justify-start">
-                                <div className="flex flex-shrink-0 items-center">
+                                <div className="flex flex-shrink-0 items-center gap-3">
                                     <img className="h-8 w-8 rounded-full" src="https://avatars.githubusercontent.com/u/5605790?v=4" alt="self portrait" />
+                                    <span className="hidden font-mono text-sm text-slate-300 md:block">julian-dev</span>
                                 </div>
                                 <div className="hidden sm:ml-6 sm:block">
                                     <div className="flex space-x-4">
@@ -49,10 +48,10 @@ export default function Navbar() {
                                                 key={item.name}
                                                 href={item.href}
                                                 className={classNames(
-                                                    item.current ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                                                    isCurrent(item.href) ? 'nav-link-active neon-drift text-white' : 'text-gray-300 hover:bg-gray-700/60 hover:text-white',
                                                     'rounded-md px-3 py-2 text-sm font-medium'
                                                 )}
-                                                aria-current={item.current ? 'page' : undefined}
+                                                aria-current={isCurrent(item.href) ? 'page' : undefined}
                                             >
                                                 {item.name}
                                             </a>
@@ -71,10 +70,10 @@ export default function Navbar() {
                                     as="a"
                                     href={item.href}
                                     className={classNames(
-                                        item.current ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                                        isCurrent(item.href) ? 'bg-gray-900/80 text-white' : 'text-gray-300 hover:bg-gray-700/60 hover:text-white',
                                         'block rounded-md px-3 py-2 text-base font-medium'
                                     )}
-                                    aria-current={item.current ? 'page' : undefined}
+                                    aria-current={isCurrent(item.href) ? 'page' : undefined}
                                 >
                                     {item.name}
                                 </Disclosure.Button>

--- a/src/app/contact/components/contactForm.tsx
+++ b/src/app/contact/components/contactForm.tsx
@@ -2,86 +2,94 @@
 
 import React, { useState } from 'react';
 
+type FormStatus = 'idle' | 'sending' | 'sent' | 'error';
+
+const inputClasses = "block w-full rounded-lg border-0 bg-white/5 py-2 text-slate-100 shadow-sm ring-1 ring-inset ring-slate-400/25 placeholder:text-slate-500 focus:ring-2 focus:ring-inset focus:ring-cyan-300/70 sm:text-sm sm:leading-6";
+
 export default function ContactForm() {
-    // Estados para los campos del formulario
     const [email, setEmail] = useState('');
     const [subject, setSubject] = useState('');
     const [message, setMessage] = useState('');
+    const [status, setStatus] = useState<FormStatus>('idle');
 
-    // Manejador del envío del formulario
     const handleSubmit = async (event: React.FormEvent) => {
-        event.preventDefault(); // Previene el comportamiento por defecto del formulario
+        event.preventDefault();
+        setStatus('sending');
 
-        // Datos del formulario
-        const formData = {
-            email,
-            subject,
-            message,
-        };
-
-        // Llamar a la API
         try {
             const response = await fetch('/api/contact_me', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify(formData),
+                body: JSON.stringify({ email, subject, message }),
             });
 
             if (!response.ok) {
                 throw new Error(`Error: ${response.statusText}`);
             }
 
-            const result = await response.json();
-            console.log(result); // Maneja la respuesta de la API
+            setStatus('sent');
+            setEmail('');
+            setSubject('');
+            setMessage('');
         } catch (error) {
-            console.error(error); // Maneja posibles errores
+            setStatus('error');
         }
     };
 
     return (
-        <form onSubmit={handleSubmit}>
-            <div className="space-y-12">
-                <div className="flex flex-col m-16">
-                    <h2 className="text-2xl font-semibold leading-7 text-slate-300">Contact Me</h2>
-
-                    <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                        {/* Campos del formulario actualizados para manejar estado */}
-                        <div className="sm:col-span-3">
-                            <label htmlFor="email" className="block text-sm font-medium leading-6 text-slate-100">Email</label>
-                            <div className="mt-2">
-                                <input id="email" name="email" type="email" autoComplete="email"
-                                    className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-slate-400 sm:text-sm sm:leading-6"
-                                    value={email} onChange={(e) => setEmail(e.target.value)} />
-                            </div>
+        <div className='mx-auto w-full max-w-2xl px-4 pb-20 sm:px-6'>
+            <header className='py-14 text-center sm:py-16'>
+                <p className='font-mono text-xs uppercase tracking-[0.35em] text-slate-400'>Contact</p>
+                <h1 className='mt-4 text-4xl font-extrabold tracking-tight text-white sm:text-5xl'>Contact Me</h1>
+                <p className='mt-4 font-mono text-sm text-slate-400'>Tell me about your project, I read everything</p>
+            </header>
+            <form onSubmit={handleSubmit} className='glass rounded-2xl p-8 sm:p-10'>
+                <div className="grid grid-cols-1 gap-x-6 gap-y-7 sm:grid-cols-2">
+                    <div>
+                        <label htmlFor="email" className="block font-mono text-xs uppercase tracking-widest text-slate-400">Email</label>
+                        <div className="mt-2">
+                            <input id="email" name="email" type="email" autoComplete="email" required
+                                className={inputClasses}
+                                value={email} onChange={(e) => setEmail(e.target.value)} />
                         </div>
+                    </div>
 
-                        <div className="sm:col-span-3">
-                            <label htmlFor="subject" className="block text-sm font-medium leading-6 text-slate-100">Subject</label>
-                            <div className="mt-2">
-                                <input type="text" name="subject" id="subject" autoComplete="family-name"
-                                    className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-slate-400 sm:text-sm sm:leading-6"
-                                    value={subject} onChange={(e) => setSubject(e.target.value)} />
-                            </div>
+                    <div>
+                        <label htmlFor="subject" className="block font-mono text-xs uppercase tracking-widest text-slate-400">Subject</label>
+                        <div className="mt-2">
+                            <input type="text" name="subject" id="subject" required
+                                className={inputClasses}
+                                value={subject} onChange={(e) => setSubject(e.target.value)} />
                         </div>
+                    </div>
 
-                        <div className="col-span-full">
-                            <label htmlFor="about" className="block text-sm font-medium leading-6 text-slate-100">Message</label>
-                            <div className="mt-2">
-                                <textarea id="about" name="about" rows={6}
-                                    className="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                                    value={message} onChange={(e) => setMessage(e.target.value)}></textarea>
-                            </div>
+                    <div className="sm:col-span-2">
+                        <label htmlFor="message" className="block font-mono text-xs uppercase tracking-widest text-slate-400">Message</label>
+                        <div className="mt-2">
+                            <textarea id="message" name="message" rows={6} required
+                                className={inputClasses}
+                                value={message} onChange={(e) => setMessage(e.target.value)}></textarea>
                         </div>
                     </div>
                 </div>
 
-                <div className="mt-6 pr-14 pb-10 flex items-center justify-end gap-x-6">
-                    <button type="button" className="text-sm font-semibold leading-6 text-gray-900">Cancel</button>
-                    <button type="submit" className="rounded-md bg-white px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm hover:bg-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Save</button>
+                <div className="mt-8 flex items-center justify-between gap-4">
+                    <div aria-live="polite" className="text-sm">
+                        {status === 'sent' && (
+                            <p role="status" className="text-emerald-300">Message sent. I&apos;ll get back to you soon.</p>
+                        )}
+                        {status === 'error' && (
+                            <p role="alert" className="text-rose-300">Your message didn&apos;t go through. Please try again.</p>
+                        )}
+                    </div>
+                    <button type="submit" disabled={status === 'sending'}
+                        className="neon-drift neon-button shrink-0 rounded-full px-6 py-2.5 text-sm font-semibold">
+                        {status === 'sending' ? 'Sending…' : 'Send message'}
+                    </button>
                 </div>
-            </div>
-        </form>
+            </form>
+        </div>
     );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
     return (
-        <main className="flex flex-col bg-slate-800 bg-opacity-75 h-screen" role='main'>
+        <main className="page-veil flex min-h-screen flex-col" role='main'>
             <Navbar />
             <div className='container mx-auto'>
                 <ContactForm />

--- a/src/app/experience/components/experienceCards.tsx
+++ b/src/app/experience/components/experienceCards.tsx
@@ -19,41 +19,37 @@ import PythonIcon from '../Icons/pythonIcon';
 import NodeJsIcon from '../Icons/nodeJsIcon';
 
 
+const ICON_SIZE = "34";
+
 const ExperienceCards = () => {
     const experiences = [
-        { key: 'farmatodo', title: 'Farmatodo', time: 'Currently, 2 years', description: 'Backend developer in <span class="font-bold">Spring Boot</span> and <span class="font-bold">NestJS</span>, developing new functionalities for microservices, working with <span class="font-bold">OracleDB</span> and <span class="font-bold">PostgreSQL</span>. Additionally, I excel in crafting <span class="font-bold">Python</span> scripts for automation and data manipulation, further enhancing operational efficiency and system integration.', logos: [{key: 0, svg: <JavaIcon width="50" height="50"/>}, {key: 1, svg: <NodeJsIcon width="50" height="50"/>}, {key: 2, svg: <PythonIcon width="50" height="50"/>}, {key: 3, svg: <SpringBootIcon width="50" height="50"/>}, {key: 4, svg: <NestJsIcon width="50" height="50"/>}, {key: 5, svg: <OracleIcon width="50" height="50"/>}, {key: 6, svg: <PostgreSqlIcon width="50" height="50"/>}, {key: 7, svg: <GoogleCloudIcon width="50" height="50"/>}]},
-        { key: 'sophos', title: 'Sophos Solutions', time: '2 years', description: 'Developed a platform for creating automated tests using <span class="font-bold">Java</span> with <span class="font-bold">Spring Boot</span> and <span class="font-bold">Angular</span>, targeting testers without Automation experience.', logos: [{key: 0, svg: <JavaIcon width="50" height="50"/>}, {key: 1, svg: <PostgreSqlIcon width="50" height="50"/>}, {key: 2, svg: <AngularIcon width="50" height="50"/>}, {key: 3, svg: <HtmlIcon width="50" height="50"/>}, {key: 4, svg: <CssIcon width="50" height="50"/>}, {key: 5, svg: <TsIcon width="50" height="50"/>}, {key: 6, svg: <AwsIcon width="50" height="50"/>}]},
-        { key: 'eltiempo', title: 'ElTiempo', time: '3 years', description: 'Full stack developer using <span class="font-bold">Angular</span> and <span class="font-bold">Symfony</span>. Improved and added new functionalities to their news website.', logos: [{key: 0, svg: <SymfonyIcon width="50" height="50"/>}, {key: 1, svg: <PhpIcon width="50" height="50"/>}, {key: 2, svg: <MySqlIcon width="50" height="50"/>}, {key: 3, svg: <HtmlIcon width="50" height="50"/>}, {key: 4, svg: <CssIcon width="50" height="50"/>}, {key: 5, svg: <JsIcon width="50" height="50"/>}]},
-        { key: 'ministry', title: 'Ministry of Environment and Sustainable Development of Colombia', time: '1 year', description: 'Developed new functionalities for an LMS platform using <span class="font-bold">PHP</span> and <span class="font-bold">MySQL</span>.', logos: [{key: 0, svg: <PhpIcon width="50" height="50"/>}, {key: 1, svg: <MySqlIcon width="65" height="65"/>}, {key: 2, svg: <HtmlIcon width="50" height="50"/>}, {key: 3, svg: <CssIcon width="50" height="50"/>}, {key: 4, svg: <JsIcon width="50" height="50"/>}]},
-        { key: 'city-hall', title: 'Fusagasuga City Hall', time: '9 months', description: 'Full stack developer with <span class="font-bold">Symfony</span>, <span class="font-bold">CSS</span>, <span class="font-bold">HTML</span>. Developed an open data platform.', logos: [{key: 0, svg: <SymfonyIcon width="50" height="50"/>}, {key: 1, svg: <PhpIcon width="50" height="50"/>},{key: 2, svg: <PostgreSqlIcon width="50" height="50"/>}, {key: 3, svg: <HtmlIcon width="50" height="50"/>}, {key: 4, svg: <CssIcon width="50" height="50"/>}, {key: 5, svg: <JsIcon width="50" height="50"/>}] },
+        { key: 'farmatodo', title: 'Farmatodo', time: 'Currently, 2 years', description: 'Backend developer in <span class="font-bold">Spring Boot</span> and <span class="font-bold">NestJS</span>, developing new functionalities for microservices, working with <span class="font-bold">OracleDB</span> and <span class="font-bold">PostgreSQL</span>. Additionally, I excel in crafting <span class="font-bold">Python</span> scripts for automation and data manipulation, further enhancing operational efficiency and system integration.', logos: [{key: 0, name: 'Java', svg: <JavaIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 1, name: 'Node.js', svg: <NodeJsIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 2, name: 'Python', svg: <PythonIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 3, name: 'Spring Boot', svg: <SpringBootIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 4, name: 'NestJS', svg: <NestJsIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 5, name: 'OracleDB', svg: <OracleIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 6, name: 'PostgreSQL', svg: <PostgreSqlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 7, name: 'Google Cloud', svg: <GoogleCloudIcon width={ICON_SIZE} height={ICON_SIZE}/>}]},
+        { key: 'sophos', title: 'Sophos Solutions', time: '2 years', description: 'Developed a platform for creating automated tests using <span class="font-bold">Java</span> with <span class="font-bold">Spring Boot</span> and <span class="font-bold">Angular</span>, targeting testers without Automation experience.', logos: [{key: 0, name: 'Java', svg: <JavaIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 1, name: 'PostgreSQL', svg: <PostgreSqlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 2, name: 'Angular', svg: <AngularIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 3, name: 'HTML', svg: <HtmlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 4, name: 'CSS', svg: <CssIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 5, name: 'TypeScript', svg: <TsIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 6, name: 'AWS', svg: <AwsIcon width={ICON_SIZE} height={ICON_SIZE}/>}]},
+        { key: 'eltiempo', title: 'ElTiempo', time: '3 years', description: 'Full stack developer using <span class="font-bold">Angular</span> and <span class="font-bold">Symfony</span>. Improved and added new functionalities to their news website.', logos: [{key: 0, name: 'Symfony', svg: <SymfonyIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 1, name: 'PHP', svg: <PhpIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 2, name: 'MySQL', svg: <MySqlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 3, name: 'HTML', svg: <HtmlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 4, name: 'CSS', svg: <CssIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 5, name: 'JavaScript', svg: <JsIcon width={ICON_SIZE} height={ICON_SIZE}/>}]},
+        { key: 'ministry', title: 'Ministry of Environment and Sustainable Development of Colombia', time: '1 year', description: 'Developed new functionalities for an LMS platform using <span class="font-bold">PHP</span> and <span class="font-bold">MySQL</span>.', logos: [{key: 0, name: 'PHP', svg: <PhpIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 1, name: 'MySQL', svg: <MySqlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 2, name: 'HTML', svg: <HtmlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 3, name: 'CSS', svg: <CssIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 4, name: 'JavaScript', svg: <JsIcon width={ICON_SIZE} height={ICON_SIZE}/>}]},
+        { key: 'city-hall', title: 'Fusagasuga City Hall', time: '9 months', description: 'Full stack developer with <span class="font-bold">Symfony</span>, <span class="font-bold">CSS</span>, <span class="font-bold">HTML</span>. Developed an open data platform.', logos: [{key: 0, name: 'Symfony', svg: <SymfonyIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 1, name: 'PHP', svg: <PhpIcon width={ICON_SIZE} height={ICON_SIZE}/>},{key: 2, name: 'PostgreSQL', svg: <PostgreSqlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 3, name: 'HTML', svg: <HtmlIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 4, name: 'CSS', svg: <CssIcon width={ICON_SIZE} height={ICON_SIZE}/>}, {key: 5, name: 'JavaScript', svg: <JsIcon width={ICON_SIZE} height={ICON_SIZE}/>}] },
     ];
 
 
     experiences.forEach((experience) => {
         experience.description = DOMPurify.sanitize(experience.description);
     });
-    
+
     return (
-        <div className="grid sm:grid-cols-2 md:grid-cols-2 grid-rows-2 gap-4">
-            {experiences.map((experience, index) => (
-                <div key={index} className="bg-white bg-opacity-80 shadow-md shadow-gray-800 rounded-3xl md:m-9 scale-90 md:hover:scale-100 md:transition md:duration-300 md:ease-in-out">
-                    <div className='h-64 bg-gray-800 rounded-t-3xl'>
-                        <div className='pt-8'>
-                            <span className="text-center rounded-full shadow-sm bg-gray-300 ml-10 text-sm p-2 text-gray-900 shadow-gray-500">{experience.time}</span>
-                        </div>
-                        <div><h3 className="text-2xl font-semibold text-white p-8">{experience.title}</h3></div>
+        <div className="grid gap-6 pb-20 sm:grid-cols-2">
+            {experiences.map((experience) => (
+                <article key={experience.key} className="glass rounded-2xl p-8 transition duration-300 hover:-translate-y-1 hover:border-slate-400/40">
+                    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2">
+                        <h2 className="text-2xl font-bold text-white">{experience.title}</h2>
+                        <span className="whitespace-nowrap rounded-full border border-slate-500/30 px-3 py-1 font-mono text-xs text-slate-300">{experience.time}</span>
                     </div>
-                    <div className='pt-8 pb-8'>
-                        <p className="text-lg text-zinc-700 pl-8 pt-8" dangerouslySetInnerHTML={{__html: experience.description}}></p>
+                    <p className="mt-5 leading-relaxed text-slate-300" dangerouslySetInnerHTML={{__html: experience.description}}></p>
+                    <div className="mt-7 flex flex-wrap gap-2">
+                        {experience.logos.map((logo) => (
+                            <div key={logo.key} title={logo.name} className="rounded-xl bg-slate-100/95 p-2 shadow-sm">{logo.svg}</div>
+                        ))}
                     </div>
-                    <div className='object-left'>
-                        <div className='grid grid-rows-2 grid-cols-4 md:grid-rows-2 md:grid-cols-5 m-6'>
-                            {experience.logos.map((logo) => (
-                                <div key={logo.key} className='md:m-2'>{logo.svg}</div>
-                            ))} 
-                        </div>
-                    </div>
-                </div>
+                </article>
             ))}
         </div>
     );

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -10,9 +10,14 @@ export const metadata: Metadata = {
 
 export default function Experience() {
   return (
-    <main className="flex flex-col" role='main'>
+    <main className="page-veil flex min-h-screen flex-col" role='main'>
       <Navbar />
-      <div className='container mx-auto'>
+      <div className='container mx-auto max-w-6xl px-4 sm:px-6'>
+        <header className='py-14 text-center sm:py-16'>
+          <p className='font-mono text-xs uppercase tracking-[0.35em] text-slate-400'>Career</p>
+          <h1 className='mt-4 text-4xl font-extrabold tracking-tight text-white sm:text-5xl'>Experience</h1>
+          <p className='mt-4 font-mono text-sm text-slate-400'>5 roles &middot; 8+ years &middot; backend first</p>
+        </header>
         <ExperienceCards />
       </div>
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,27 +3,101 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
+  --ink: #05080d;
+  --text: #e6edf3;
+  --muted: #9aa7b8;
+  --line: rgba(148, 163, 184, 0.16);
+  /* Base hue matches the canvas animation's cyan range; .neon-drift rotates it
+     on the same ~60s cycle the canvas uses (0.1deg per frame at 60fps). */
+  --neon: 190 95% 60%;
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
+  color: var(--text);
+  background: var(--ink);
+}
+
+:focus-visible {
+  outline: 2px solid hsl(var(--neon));
+  outline-offset: 2px;
+}
+
+@keyframes neon-drift {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
+@layer components {
+  /* Translucent veil between the neon canvas and the content of every page. */
+  .page-veil {
+    background: linear-gradient(
       to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+      rgba(11, 18, 32, 0.55),
+      rgba(5, 8, 13, 0.82)
+    );
+  }
+
+  /* Dark glass panel that lets the canvas glow through. */
+  .glass {
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid var(--line);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  /* Signature: accent elements drift through hues in sync with the canvas. */
+  .neon-drift {
+    animation: neon-drift 60s linear infinite;
+  }
+
+  .neon-glow {
+    text-shadow: 0 0 18px hsl(var(--neon) / 0.55),
+      0 0 70px hsl(var(--neon) / 0.3);
+  }
+
+  .neon-button {
+    border: 1px solid hsl(var(--neon) / 0.65);
+    color: hsl(var(--neon) / 0.95);
+    box-shadow: 0 0 16px hsl(var(--neon) / 0.15),
+      inset 0 0 12px hsl(var(--neon) / 0.06);
+    transition: background-color 200ms ease, box-shadow 200ms ease;
+  }
+
+  .neon-button:hover:not(:disabled) {
+    background-color: hsl(var(--neon) / 0.12);
+    box-shadow: 0 0 24px hsl(var(--neon) / 0.3),
+      inset 0 0 12px hsl(var(--neon) / 0.08);
+  }
+
+  .neon-button:disabled {
+    opacity: 0.55;
+  }
+
+  .nav-link-active {
+    position: relative;
+  }
+
+  .nav-link-active::after {
+    content: "";
+    position: absolute;
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: -0.125rem;
+    height: 2px;
+    border-radius: 9999px;
+    background: hsl(var(--neon));
+    box-shadow: 0 0 12px hsl(var(--neon) / 0.8);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .neon-drift {
+      animation: none;
+    }
+  }
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
-import { Raleway } from "next/font/google";
+import { IBM_Plex_Mono, Raleway } from "next/font/google";
 
 import "./globals.css";
 import DynamicCanvasBackgroundComponent from "./components/canvasBackground/dynamicCanvasBackground";
 
-const raleway = Raleway({ subsets: ["latin"] });
+const raleway = Raleway({ subsets: ["latin"], variable: "--font-raleway" });
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-plex-mono",
+});
 
 export const metadata: Metadata = {
   title: {
@@ -15,10 +20,11 @@ export const metadata: Metadata = {
   keywords: ["Backend Developer", "Full Stack Developer", "Java", "Python", "JavaScript", "TypeScript", "Clean Architecture", "Julian Portfolio"],
   authors: [{ name: "Julian" }],
   creator: "Julian",
+  metadataBase: new URL("https://julian-dev.dev"),
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://julianjjo.github.io/", // Adjust if different
+    url: "https://julian-dev.dev/",
     title: "Julian | Backend & Full Stack Developer",
     description: "Seasoned Backend Developer specializing in creating robust, scalable solutions.",
     siteName: "Julian Portfolio",
@@ -41,7 +47,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={raleway.className}>
+      <body className={`${raleway.variable} ${plexMono.variable} font-sans`}>
         <DynamicCanvasBackgroundComponent />
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
     "@type": "Person",
     "name": "Julian",
     "jobTitle": "Backend & Full Stack Developer",
-    "url": "https://julianjjo.github.io/",
+    "url": "https://julian-dev.dev/",
     "sameAs": [
       "https://github.com/julianjjo",
       // Add LinkedIn if available
@@ -21,25 +21,49 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min flex-col h-full md:h-screen bg-gray-800 bg-opacity-75">
+    <main className="page-veil flex min-h-screen flex-col">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <Navbar />
-      <div className="flex flex-col items-center justify-center md:h-full">
-        <div>
-          <div className="text-center p-20">
-            <h1 className="text-7xl font-bold items-center" role="heading">About Me</h1>
-          </div>
-          <div className="text-center p-8 text-xl">
-            <p>I am a seasoned Backend Developer with 8 years of experience specializing in creating robust, scalable solutions using <span className="font-bold">Java</span>, <span className="font-bold">JavaScript</span>, <span className="font-bold">Python</span>, and <span className="font-bold">PHP</span>. My expertise extends to Full Stack development, proficiently using <span className="font-bold">JavaScript</span>, <span className="font-bold">TypeScript</span>, <span className="font-bold">CSS</span>, and <span className="font-bold">HTML</span> to deliver dynamic and responsive user interfaces.</p>
-          </div>
-          <div className="text-center pb-20 italic">
-            <p>My journey in tech has also embraced cloud technologies, managing high-quality technical implementations on AWS and Google Cloud. Whether working on microservices or monolithic architectures, I prioritize clean code, technical excellence, and clean architecture principles to drive efficient and effective solutions.</p>
-          </div>
+      <section className="flex flex-1 flex-col items-center justify-center px-6 py-20 text-center">
+        <p className="font-mono text-xs uppercase tracking-[0.35em] text-slate-400 sm:text-sm">
+          Backend &amp; Full Stack Developer
+        </p>
+        <h1 className="mt-6 text-6xl font-extrabold tracking-tight text-white sm:text-7xl md:text-8xl">
+          <span className="neon-drift neon-glow">Julian</span>
+        </h1>
+        <p className="mt-5 font-mono text-sm text-slate-400">
+          8+ years building robust, scalable systems
+        </p>
+        <div className="mt-12 max-w-3xl space-y-6 text-lg leading-relaxed text-slate-300">
+          <p>I am a seasoned Backend Developer with 8 years of experience specializing in creating robust, scalable solutions using <span className="font-bold text-slate-100">Java</span>, <span className="font-bold text-slate-100">JavaScript</span>, <span className="font-bold text-slate-100">Python</span>, and <span className="font-bold text-slate-100">PHP</span>. My expertise extends to Full Stack development, proficiently using <span className="font-bold text-slate-100">JavaScript</span>, <span className="font-bold text-slate-100">TypeScript</span>, <span className="font-bold text-slate-100">CSS</span>, and <span className="font-bold text-slate-100">HTML</span> to deliver dynamic and responsive user interfaces.</p>
+          <p className="italic text-slate-400">My journey in tech has also embraced cloud technologies, managing high-quality technical implementations on AWS and Google Cloud. Whether working on microservices or monolithic architectures, I prioritize clean code, technical excellence, and clean architecture principles to drive efficient and effective solutions.</p>
         </div>
-      </div>
+        <div className="mt-14 flex flex-wrap items-center justify-center gap-4">
+          <a
+            href="/contact"
+            className="neon-drift neon-button rounded-full px-6 py-2.5 text-sm font-semibold"
+          >
+            Get in touch
+          </a>
+          <a
+            href="/experience"
+            className="rounded-full border border-slate-500/40 px-6 py-2.5 text-sm font-semibold text-slate-200 transition-colors hover:border-slate-300/60 hover:text-white"
+          >
+            View experience
+          </a>
+          <a
+            href="https://github.com/julianjjo"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-sm text-slate-400 underline-offset-4 transition-colors hover:text-slate-200 hover:underline"
+          >
+            github.com/julianjjo
+          </a>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
             allow: '/',
             disallow: '/private/',
         },
-        sitemap: 'https://julianjjo.github.io/sitemap.xml',
+        sitemap: 'https://julian-dev.dev/sitemap.xml',
     }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-    const baseUrl = 'https://julianjjo.github.io'
+    const baseUrl = 'https://julian-dev.dev'
 
     return [
         {
@@ -15,6 +15,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.8,
+        },
+        {
+            url: `${baseUrl}/skills`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.6,
         },
         {
             url: `${baseUrl}/contact`,

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Navbar from '../components/navbar/navbar';
+import { Metadata } from "next";
+import JavaIcon from '../experience/Icons/javaIcon';
+import JsIcon from '../experience/Icons/jsIcon';
+import TsIcon from '../experience/Icons/tsIcon';
+import PythonIcon from '../experience/Icons/pythonIcon';
+import PhpIcon from '../experience/Icons/phpIcon';
+import HtmlIcon from '../experience/Icons/htmlIcon';
+import CssIcon from '../experience/Icons/cssIcon';
+import SpringBootIcon from '../experience/Icons/springBootIcon';
+import NestJsIcon from '../experience/Icons/nestjsIcon';
+import NodeJsIcon from '../experience/Icons/nodeJsIcon';
+import AngularIcon from '../experience/Icons/angularIcon';
+import SymfonyIcon from '../experience/Icons/symfonyIcon';
+import OracleIcon from '../experience/Icons/oracleBootIcon';
+import PostgreSqlIcon from '../experience/Icons/postgreSqlIcon';
+import MySqlIcon from '../experience/Icons/mySqlIcon';
+import AwsIcon from '../experience/Icons/awsIcon';
+import GoogleCloudIcon from '../experience/Icons/googleCloudIcon';
+
+export const metadata: Metadata = {
+    title: "Skills",
+    description: "The languages, frameworks, databases, and cloud platforms Julian works with as a Backend and Full Stack Developer.",
+};
+
+const ICON_SIZE = "30";
+
+export default function Skills() {
+    const groups = [
+        {
+            key: 'languages',
+            title: 'Languages',
+            skills: [
+                { name: 'Java', icon: <JavaIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'JavaScript', icon: <JsIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'TypeScript', icon: <TsIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'Python', icon: <PythonIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'PHP', icon: <PhpIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'HTML', icon: <HtmlIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'CSS', icon: <CssIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+            ],
+        },
+        {
+            key: 'frameworks',
+            title: 'Frameworks & Runtimes',
+            skills: [
+                { name: 'Spring Boot', icon: <SpringBootIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'NestJS', icon: <NestJsIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'Node.js', icon: <NodeJsIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'Angular', icon: <AngularIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'Symfony', icon: <SymfonyIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+            ],
+        },
+        {
+            key: 'databases',
+            title: 'Databases',
+            skills: [
+                { name: 'OracleDB', icon: <OracleIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'PostgreSQL', icon: <PostgreSqlIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'MySQL', icon: <MySqlIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+            ],
+        },
+        {
+            key: 'cloud',
+            title: 'Cloud',
+            skills: [
+                { name: 'AWS', icon: <AwsIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+                { name: 'Google Cloud', icon: <GoogleCloudIcon width={ICON_SIZE} height={ICON_SIZE} /> },
+            ],
+        },
+    ];
+
+    return (
+        <main className="page-veil flex min-h-screen flex-col" role='main'>
+            <Navbar />
+            <div className='container mx-auto max-w-6xl px-4 sm:px-6'>
+                <header className='py-14 text-center sm:py-16'>
+                    <p className='font-mono text-xs uppercase tracking-[0.35em] text-slate-400'>Toolbox</p>
+                    <h1 className='mt-4 text-4xl font-extrabold tracking-tight text-white sm:text-5xl'>Skills</h1>
+                    <p className='mt-4 font-mono text-sm text-slate-400'>What I build with, from the JVM to the cloud</p>
+                </header>
+                <div className='grid gap-6 pb-20 sm:grid-cols-2'>
+                    {groups.map((group) => (
+                        <section key={group.key} aria-labelledby={`skills-${group.key}`} className='glass rounded-2xl p-8'>
+                            <h2 id={`skills-${group.key}`} className='font-mono text-xs uppercase tracking-[0.3em] text-slate-400'>{group.title}</h2>
+                            <ul className='mt-6 flex flex-wrap gap-3'>
+                                {group.skills.map((skill) => (
+                                    <li key={skill.name} className='flex items-center gap-3 rounded-full border border-slate-500/30 py-1.5 pl-1.5 pr-4'>
+                                        <span className='flex h-10 w-10 items-center justify-center rounded-full bg-slate-100/95'>{skill.icon}</span>
+                                        <span className='text-sm font-medium text-slate-200'>{skill.name}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-raleway)", "sans-serif"],
+        mono: ["var(--font-plex-mono)", "monospace"],
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
…tact form UX

- Signature accent drifts through hues on the same 60s cycle as the canvas background
- Dark glass panels (backdrop-blur) replace opaque blocks so the neon shows through
- IBM Plex Mono for eyebrows, badges and labels alongside Raleway
- New /skills page reusing the tech icons (navbar Skills link no longer dead)
- Contact form: Send message button with loading/success/error states, required fields
- Experience cards: glass style, uniform icon chips, no scale-90 trick
- prefers-reduced-motion: canvas renders a static composition, accent stops drifting
- SEO: julian-dev.dev in metadata/sitemap/robots, /skills added to sitemap
- Add ts-node devDependency (jest.config.ts requires it)